### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/rand-theme.el
+++ b/rand-theme.el
@@ -65,7 +65,7 @@ If this is non-nil then it will have a higher precedence than `rand-theme-unwant
   (let ((available-themes (custom-available-themes)) (theme nil))
     (if (null rand-theme-wanted)
         ;; Filter out unwanted themes
-        (mapc '(lambda (unwanted) (setq available-themes (remove unwanted available-themes))) rand-theme-unwanted)
+        (mapc (lambda (unwanted) (setq available-themes (remove unwanted available-themes))) rand-theme-unwanted)
       ;; No need to filter since we already have a list we want to use
       (setq available-themes rand-theme-wanted))
     ;; return themes to use
@@ -74,7 +74,7 @@ If this is non-nil then it will have a higher precedence than `rand-theme-unwant
 (defun rand-theme--load-theme (theme)
   ""
   ;; Disable ALL themes
-  (mapcar 'disable-theme custom-enabled-themes)
+  (mapc 'disable-theme custom-enabled-themes)
   (load-theme theme t)
   (message "Loaded Theme: %s" (symbol-name theme)))
 


### PR DESCRIPTION
- Remove quote from lambda expression
- Use mapc instead of mapcar because return value of mapcar is unused.

There are following byte-compile warnings. This patch fixes them.

```
rand-theme.el:70:30:Warning: (lambda (unwanted) ...) quoted with ' rather than
    with #'

In rand-theme--load-theme:
rand-theme.el:77:4:Warning: `mapcar' called for effect; use `mapc' or `dolist'
    instead
```
